### PR TITLE
Add Stripe Checkout server example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,28 @@
-Hello Codex
+# Stripe Checkout Server
+
+This repository contains a minimal example of a Stripe Checkout server implemented with Node.js and Express.
+
+The server lives in the `stripe-checkout-server` directory.
+
+## Setup
+
+1. Install dependencies (requires internet access):
+
+   ```bash
+   cd stripe-checkout-server
+   npm install
+   ```
+
+2. Set your Stripe secret key in the environment:
+
+   ```bash
+   export STRIPE_SECRET_KEY=your-key-here
+   ```
+
+3. Start the server:
+
+   ```bash
+   npm start
+   ```
+
+The server exposes a `POST /create-checkout-session` endpoint that returns a Checkout Session ID.

--- a/stripe-checkout-server/.gitignore
+++ b/stripe-checkout-server/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+.env

--- a/stripe-checkout-server/package.json
+++ b/stripe-checkout-server/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "stripe-checkout-server",
+  "version": "1.0.0",
+  "description": "Example Stripe Checkout server",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js"
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "stripe": "^14.0.0"
+  }
+}

--- a/stripe-checkout-server/server.js
+++ b/stripe-checkout-server/server.js
@@ -1,0 +1,31 @@
+const express = require('express');
+const Stripe = require('stripe');
+
+const app = express();
+const stripe = Stripe(process.env.STRIPE_SECRET_KEY);
+
+app.use(express.json());
+
+app.post('/create-checkout-session', async (req, res) => {
+  try {
+    const session = await stripe.checkout.sessions.create({
+      mode: 'payment',
+      line_items: [{
+        price_data: {
+          currency: 'usd',
+          product_data: { name: 'Example product' },
+          unit_amount: 2000,
+        },
+        quantity: 1,
+      }],
+      success_url: req.body.success_url || 'https://example.com/success',
+      cancel_url: req.body.cancel_url || 'https://example.com/cancel',
+    });
+    res.json({ id: session.id });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+const port = process.env.PORT || 4242;
+app.listen(port, () => console.log(`Server running on port ${port}`));


### PR DESCRIPTION
## Summary
- create a `stripe-checkout-server` directory with a simple Node.js server
- document how to run the server

## Testing
- `node stripe-checkout-server/server.js` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_686cc7d51e64832b85d9104bb5d77cd9